### PR TITLE
MSB-57: Part 2 - Add published message validations

### DIFF
--- a/lib/railway_ipc/models/published_message.rb
+++ b/lib/railway_ipc/models/published_message.rb
@@ -3,10 +3,6 @@ module RailwayIpc
     self.table_name = 'railway_ipc_published_messages'
     self.primary_key = "uuid"
 
-    attr_reader :decoded_message
-    self.table_name = 'railway_ipc_consumed_messages'
-    self.primary_key = 'uuid'
-
     validates :uuid, :status, presence: true
 
     def self.store_message(exchange_name, message)

--- a/lib/railway_ipc/models/published_message.rb
+++ b/lib/railway_ipc/models/published_message.rb
@@ -3,6 +3,12 @@ module RailwayIpc
     self.table_name = 'railway_ipc_published_messages'
     self.primary_key = "uuid"
 
+    attr_reader :decoded_message
+    self.table_name = 'railway_ipc_consumed_messages'
+    self.primary_key = 'uuid'
+
+    validates :uuid, :status, presence: true
+
     def self.store_message(exchange_name, message)
       encoded_message = RailwayIpc::Rabbitmq::Payload.encode(message)
       self.create(

--- a/priv/migrations/add_railway_ipc_published_messages.rb
+++ b/priv/migrations/add_railway_ipc_published_messages.rb
@@ -2,10 +2,10 @@ class AddRailwayIpcPublishedMessages < ActiveRecord::Migration
   def change
     create_table :railway_ipc_published_messages, id: false do | t |
       t.uuid :uuid, null: false
-      t.string :message_type, null: false
+      t.string :message_type
       t.uuid :user_uuid
       t.uuid :correlation_id
-      t.text :encoded_message, null: false
+      t.text :encoded_message
       t.string :status, null: false
       t.string :exchange
 

--- a/spec/railway_ipc/models/published_message_spec.rb
+++ b/spec/railway_ipc/models/published_message_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe RailwayIpc::PublishedMessage do
-  describe 'initial save to DB' do
+RSpec.describe RailwayIpc::PublishedMessage, type: :model do
+  describe 'validations' do
+    it { should validate_presence_of(:uuid) }
+    it { should validate_presence_of(:status) }
+  end
+
+  describe '#create' do
     it 'saves an inserted_at date for the current time' do
       msg = RailwayIpc::PublishedMessage.create({
         uuid: SecureRandom.uuid,


### PR DESCRIPTION
Removes null constraints for :message_type & :encoded_message while also adding presence validations for :uuid and :status.

Relates to Jira [MSB-57](https://flatiron.atlassian.net/browse/MSB-57)