### PR TITLE
MSB-236: Update version to be 0.1.4 for Ruby Gem shipment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    railway-ipc (0.1.3)
+    railway-ipc (0.1.4)
       bunny (~> 2.2.0)
       sneakers (~> 2.3.5)
 

--- a/lib/railway_ipc/version.rb
+++ b/lib/railway_ipc/version.rb
@@ -1,3 +1,3 @@
 module RailwayIpc
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/support/rails_app/Gemfile.lock
+++ b/spec/support/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    railway-ipc (0.1.3)
+    railway-ipc (0.1.4)
       bunny (~> 2.2.0)
       sneakers (~> 2.3.5)
 


### PR DESCRIPTION
# Description 

Updates versioning to prep shipment to Ruby Gems.

Closes out [MSB-236](https://flatiron.atlassian.net/browse/MSB-236)