### PR TITLE
add vhost to bunny connection

### DIFF
--- a/lib/railway_ipc/rabbitmq/adapter.rb
+++ b/lib/railway_ipc/rabbitmq/adapter.rb
@@ -23,6 +23,7 @@ module RailwayIpc
                                     user: settings[:user],
                                     pass: settings[:pass],
                                     port: settings[:port],
+                                    vhost: settings[:vhost],
                                     automatic_recovery: false,
                                     logger: RailwayIpc.bunny_logger}.merge(options)
         )

--- a/lib/railway_ipc/rabbitmq/adapter.rb
+++ b/lib/railway_ipc/rabbitmq/adapter.rb
@@ -18,15 +18,16 @@ module RailwayIpc
         @queue_name = queue_name
         @exchange_name = exchange_name
         settings = AMQ::Settings.parse_amqp_url(amqp_url)
+        vhost = settings[:vhost] || '/'
         @connection = Bunny.new({
                                     host: settings[:host],
                                     user: settings[:user],
                                     pass: settings[:pass],
                                     port: settings[:port],
-                                    vhost: settings[:vhost],
+                                    vhost: vhost,
                                     automatic_recovery: false,
-                                    logger: RailwayIpc.bunny_logger}.merge(options)
-        )
+                                    logger: RailwayIpc.bunny_logger
+                                }.merge(options))
       end
 
       def publish(message, options = {})


### PR DESCRIPTION
We should pass in the vhost we parse out of the URL to allow us to use non `/` vhosts on rabbitmq.