### PR TITLE
[RAIL-27] Ensure essential message ids

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,7 @@
+# Changelog for v0.x
+
+## v0.1.7 (2020-06-29)
+
+### Enhancements
+
+- Correlation ID and message UUID are auto generated for messages for IDs are not passed in [#23](https://github.com/learn-co/railway_ipc_gem/pull/23)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    amq-protocol (2.3.0)
+    amq-protocol (2.3.1)
     arel (7.1.4)
     builder (3.2.4)
     bunny (2.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    railway-ipc (0.1.6)
+    railway-ipc (0.1.7)
       bunny (~> 2.2.0)
       sneakers (~> 2.3.5)
 

--- a/lib/railway_ipc/publisher.rb
+++ b/lib/railway_ipc/publisher.rb
@@ -18,8 +18,8 @@ module RailwayIpc
     end
 
     def publish(message, published_message_store=RailwayIpc::PublishedMessage)
-      message = ensure_message_uuid(message)
-      message = ensure_correlation_id(message)
+      ensure_message_uuid(message)
+      ensure_correlation_id(message)
       RailwayIpc.logger.info(message, 'Publishing message')
 
       result = super(RailwayIpc::Rabbitmq::Payload.encode(message))

--- a/lib/railway_ipc/publisher.rb
+++ b/lib/railway_ipc/publisher.rb
@@ -18,13 +18,36 @@ module RailwayIpc
     end
 
     def publish(message, published_message_store=RailwayIpc::PublishedMessage)
+      message = ensure_message_uuid(message)
+      message = ensure_correlation_id(message)
       RailwayIpc.logger.info(message, 'Publishing message')
+
       result = super(RailwayIpc::Rabbitmq::Payload.encode(message))
       published_message_store.store_message(self.class.exchange_name, message)
       result
     rescue RailwayIpc::InvalidProtobuf => e
       RailwayIpc.logger.error(message, 'Invalid protobuf')
       raise e
+    end
+
+    private
+
+    def ensure_message_uuid(message)
+      if message.uuid.blank?
+        message.uuid = SecureRandom.uuid
+        message
+      else
+        message
+      end
+    end
+
+    def ensure_correlation_id(message)
+      if message.correlation_id.blank?
+        message.correlation_id = SecureRandom.uuid
+        message
+      else
+        message
+      end
     end
   end
 end

--- a/lib/railway_ipc/version.rb
+++ b/lib/railway_ipc/version.rb
@@ -1,3 +1,3 @@
 module RailwayIpc
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/spec/railway_ipc/publisher_spec.rb
+++ b/spec/railway_ipc/publisher_spec.rb
@@ -1,6 +1,9 @@
 RSpec.describe RailwayIpc::Publisher do
   let(:publisher) { RailwayIpc::TestPublisher.instance }
-  let(:message)   { LearnIpc::Commands::TestMessage.new }
+  let(:message)   { LearnIpc::Commands::TestMessage.new(
+    uuid: SecureRandom.uuid,
+    correlation_id: SecureRandom.uuid
+  ) }
   let(:encoded_message) { Base64.encode64(LearnIpc::Commands::TestMessage.encode(message)) }
 
   it "knows its exchange" do
@@ -10,5 +13,31 @@ RSpec.describe RailwayIpc::Publisher do
   it "initializes the Sneakers publisher with the correct exchange and exchange type" do
     expect(publisher.instance_variable_get(:@opts)[:exchange]).to eq("test:events")
     expect(publisher.instance_variable_get(:@opts)[:exchange_options][:type]).to eq(:fanout)
+  end
+
+  it "auto generates a message uuid if one is not passed in" do
+    message.uuid = ""
+    uuid = SecureRandom.uuid
+
+    message_with_uuid = message.clone
+    message_with_uuid.uuid = uuid
+
+    allow(SecureRandom).to receive(:uuid).and_return(uuid)
+    allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything())
+    expect(RailwayIpc::Rabbitmq::Payload).to receive(:encode).at_least(1).times.with(message_with_uuid).and_call_original
+    publisher.publish(message)
+  end
+
+  it "auto generates a correlation_id if one is not passed in" do
+    message.correlation_id = ""
+    correlation_id = SecureRandom.uuid
+
+    message_with_correlation_id = message.clone
+    message_with_correlation_id.correlation_id = correlation_id
+
+    allow(SecureRandom).to receive(:uuid).and_return(correlation_id)
+    allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything())
+    expect(RailwayIpc::Rabbitmq::Payload).to receive(:encode).at_least(1).times.with(message_with_correlation_id).and_call_original
+    publisher.publish(message)
   end
 end


### PR DESCRIPTION
Ensures that there is a UUID and Correlation ID on any message sent. 