### PR TITLE
Create a nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,16 @@ workflows:
   test:
     jobs:
       - test
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test
 experimental:
   notify:
     branches:


### PR DESCRIPTION
There have been several times on other projects (pheoyonce, flatchat) where dependencies went out of date, missing, etc. Adding a nightly build will surface these issues earlier preventing situations where we need to scramble to get builds to pass when trying to make a time sensitive change.