### PR TITLE
Refactor RailwayIpc::Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+* `RailwayIpc.configure` now takes `device`, `level`, and `formatter` instead of a complete `Logger` instance. The instance is now managed internally by Railway.
+
 ### Removed
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And then execute:
 ```ruby
 # config/initializers/railway_ipc.rb
 
-RailwayIpc.configure(logger: Rails.logger)
+RailwayIpc.configure(STDOUT, Logger::INFO, MyFormatter)
 ```
 
 * Load the rake tasks in your Rakefile

--- a/lib/railway_ipc.rb
+++ b/lib/railway_ipc.rb
@@ -29,16 +29,16 @@ module RailwayIpc
     Rake::Task['sneakers:run'].invoke
   end
 
-  def self.configure(logger: ::Logger.new(STDOUT))
-    @logger = RailwayIpc::Logger.new(logger)
+  def self.configure(log_device=STDOUT, level=::Logger::INFO, log_formatter=nil)
+    @logger = RailwayIpc::Logger.new(log_device, level, log_formatter)
   end
 
   def self.logger
-    @logger || RailwayIpc::Logger.new(::Logger.new(STDOUT))
+    @logger || RailwayIpc::Logger.new(STDOUT)
   end
 
   def self.bunny_logger
-    logger.logger
+    logger
   end
 
   def self.bunny_connection

--- a/lib/railway_ipc/consumer/consumer.rb
+++ b/lib/railway_ipc/consumer/consumer.rb
@@ -44,10 +44,10 @@ module RailwayIpc
       RailwayIpc::ProcessIncomingMessage.call(self, message)
       ack!
     rescue StandardError => e
-      RailwayIpc.logger.log_exception(
+      RailwayIpc.logger.error(
+        e.message,
         feature: 'railway_consumer',
         error: e.class,
-        error_message: e.message,
         payload: payload
       )
       raise e

--- a/lib/railway_ipc/consumer/process_incoming_message.rb
+++ b/lib/railway_ipc/consumer/process_incoming_message.rb
@@ -16,8 +16,8 @@ module RailwayIpc
 
       def run
         logger.warn(
-          incoming_message.decoded,
-          "Ignoring unknown message of type '#{incoming_message.type}'"
+          "Ignoring unknown message of type '#{incoming_message.type}'",
+          protobuf: incoming_message.decoded
         )
       end
     end
@@ -36,8 +36,8 @@ module RailwayIpc
 
       def run
         logger.warn(
-          incoming_message.decoded,
-          "Ignoring message, no registered handler for '#{incoming_message.type}'"
+          "Ignoring message, no registered handler for '#{incoming_message.type}'",
+          protobuf: incoming_message.decoded
         )
       end
     end
@@ -81,7 +81,7 @@ module RailwayIpc
 
     def raise_message_invalid_error
       error = "Message is invalid: #{incoming_message.stringify_errors}."
-      logger.error(incoming_message.decoded, error)
+      logger.error(error, protobuf: incoming_message.decoded)
       raise RailwayIpc::IncomingMessage::InvalidMessage.new(error)
     end
 

--- a/lib/railway_ipc/handler.rb
+++ b/lib/railway_ipc/handler.rb
@@ -11,12 +11,12 @@ module RailwayIpc
     end
 
     def handle(message)
-      RailwayIpc.logger.info(message, 'Handling message')
+      RailwayIpc.logger.info('Handling message', protobuf: message)
       response = self.class.block.call(message)
       if response.success?
-        RailwayIpc.logger.info(message, 'Successfully handled message')
+        RailwayIpc.logger.info('Successfully handled message', protobuf: message)
       else
-        RailwayIpc.logger.error(message, 'Failed to handle message')
+        RailwayIpc.logger.error('Failed to handle message', protobuf: message)
       end
 
       response

--- a/lib/railway_ipc/publisher.rb
+++ b/lib/railway_ipc/publisher.rb
@@ -21,16 +21,16 @@ module RailwayIpc
     end
 
     def publish(message, published_message_store=RailwayIpc::PublishedMessage)
-      RailwayIpc.logger.logger.warn('DEPRECATED: Use new PublisherInstance class')
+      RailwayIpc.logger.warn('DEPRECATED: Use new PublisherInstance class')
       ensure_message_uuid(message)
       ensure_correlation_id(message)
-      RailwayIpc.logger.info(message, 'Publishing message')
+      RailwayIpc.logger.info('Publishing message', protobuf: message)
 
       result = super(RailwayIpc::Rabbitmq::Payload.encode(message))
       published_message_store.store_message(self.class.exchange_name, message)
       result
     rescue RailwayIpc::InvalidProtobuf => e
-      RailwayIpc.logger.error(message, 'Invalid protobuf')
+      RailwayIpc.logger.error('Invalid protobuf', protobuf: message)
       raise e
     end
 
@@ -68,15 +68,15 @@ module RailwayIpc
     def publish(message)
       message.uuid = SecureRandom.uuid if message.uuid.blank?
       message.correlation_id = SecureRandom.uuid if message.correlation_id.blank?
-      RailwayIpc.logger.info(message, 'Publishing message')
+      RailwayIpc.logger.info('Publishing message', protobuf: message)
 
       stored_message = message_store.store_message(exchange_name, message)
       super(RailwayIpc::Rabbitmq::Payload.encode(message))
     rescue RailwayIpc::InvalidProtobuf => e
-      RailwayIpc.logger.error(message, 'Invalid protobuf')
+      RailwayIpc.logger.error('Invalid protobuf', protobuf: message)
       raise e
     rescue ActiveRecord::RecordInvalid => e
-      RailwayIpc.logger.error(message, 'Failed to store outgoing message')
+      RailwayIpc.logger.error('Failed to store outgoing message', protobuf: message)
       raise RailwayIpc::FailedToStoreOutgoingMessage.new(e)
     rescue StandardError => e
       stored_message&.destroy

--- a/lib/railway_ipc/responder.rb
+++ b/lib/railway_ipc/responder.rb
@@ -11,7 +11,7 @@ module RailwayIpc
     end
 
     def respond(request)
-      RailwayIpc.logger.info(request, 'Responding to request')
+      RailwayIpc.logger.info('Responding to request', request: request)
       response = self.class.block.call(request)
       raise ResponseTypeError.new(response.class) unless response.is_a?(Google::Protobuf::MessageExts)
 

--- a/lib/railway_ipc/rpc/client/client.rb
+++ b/lib/railway_ipc/rpc/client/client.rb
@@ -44,7 +44,7 @@ module RailwayIpc
       case decoded_payload.type
       when *registered_handlers
         @message = get_message_class(decoded_payload).decode(decoded_payload.message)
-        RailwayIpc.logger.info(message, 'Handling response')
+        RailwayIpc.logger.info('Handling response', protobuf: message)
         RailwayIpc::Response.new(message, success: true)
       else
         @message = LearnIpc::ErrorMessage.decode(decoded_payload.message)
@@ -78,10 +78,10 @@ module RailwayIpc
     private
 
     def log_exception(exception, payload)
-      RailwayIpc.logger.log_exception(
+      RailwayIpc.logger.error(
+        exception.message,
         feature: 'railway_consumer',
         error: exception.class,
-        error_message: exception.message,
         payload: decode_for_error(exception, payload)
       )
     end
@@ -99,7 +99,7 @@ module RailwayIpc
     end
 
     def publish_message
-      RailwayIpc.logger.info(request_message, 'Sending request')
+      RailwayIpc.logger.info('Sending request', request_message: request_message)
       rabbit_connection.publish(RailwayIpc::Rabbitmq::Payload.encode(request_message), routing_key: '')
     end
 

--- a/lib/railway_ipc/rpc/server/server.rb
+++ b/lib/railway_ipc/rpc/server/server.rb
@@ -45,10 +45,10 @@ module RailwayIpc
         raise RailwayIpc::UnhandledMessageError.new("#{self.class} does not know how to handle #{decoded_payload.type}")
       end
     rescue StandardError => e
-      RailwayIpc.logger.log_exception(
+      RailwayIpc.logger.error(
+        e.message,
         feature: 'railway_consumer',
         error: e.class,
-        error_message: e.message,
         payload: payload
       )
       raise e
@@ -59,7 +59,7 @@ module RailwayIpc
     def handle_request(payload)
       response = work(payload)
     rescue StandardError => e
-      RailwayIpc.logger.error(message, "Error responding to message. Error: #{e.class}, #{e.message}")
+      RailwayIpc.logger.error("Error responding to message. Error: #{e.class}, #{e.message}", protobuf: message)
       response = self.class.rpc_error_adapter_class.error_message(e, message)
     ensure
       if response

--- a/spec/integration/i_spec.rb
+++ b/spec/integration/i_spec.rb
@@ -5,9 +5,4 @@ require 'railway_ipc'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].sort.each { |f| require f }
 
-logger = Logger.new(STDOUT)
-logger.level = :fatal
-
-RailwayIpc.configure(
-  logger: logger
-)
+RailwayIpc.configure(IO::NULL)

--- a/spec/railway_ipc/handler_spec.rb
+++ b/spec/railway_ipc/handler_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe RailwayIpc::Handler do
 
   context 'when the message is handled successfully' do
     it 'logs the message was successful' do
-      expect(RailwayIpc.logger).to receive(:info).with(message, 'Handling message')
-      expect(RailwayIpc.logger).to receive(:info).with(message, 'Successfully handled message')
+      expect(RailwayIpc.logger).to \
+        receive(:info).with('Handling message', protobuf: message)
+
+      expect(RailwayIpc.logger).to \
+        receive(:info).with('Successfully handled message', protobuf: message)
+
       handler.handle(message)
     end
   end
@@ -20,8 +24,12 @@ RSpec.describe RailwayIpc::Handler do
     end
 
     it 'logs the message failed' do
-      expect(RailwayIpc.logger).to receive(:info).with(message, 'Handling message')
-      expect(RailwayIpc.logger).to receive(:error).with(message, 'Failed to handle message')
+      expect(RailwayIpc.logger).to \
+        receive(:info).with('Handling message', protobuf: message)
+
+      expect(RailwayIpc.logger).to \
+        receive(:error).with('Failed to handle message', protobuf: message)
+
       handler.handle(message)
     end
   end

--- a/spec/railway_ipc/logger_spec.rb
+++ b/spec/railway_ipc/logger_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+%w[fatal error warn info debug].each do |level|
+  RSpec.describe RailwayIpc::Logger, "##{level}" do
+    let(:io) { StringIO.new }
+    let(:parsed_log_str) { JSON.parse(io.string, symbolize_names: true) }
+
+    subject { described_class.new(io, Logger::DEBUG) }
+
+    context 'when there is a bare message' do
+      before(:each) { subject.send(level, 'some message') }
+
+      it { expect(io.string).to include(level.upcase) }
+      it { expect(io.string).to include('some message') }
+    end
+
+    context 'when extra data is provided' do
+      before(:each) { subject.send(level, 'some message', protobuf: stubbed_protobuf) }
+
+      it { expect(io.string).to include(level.upcase) }
+      it { expect(io.string).to include('some message') }
+
+      it 'includes the data in the output' do
+        expect(io.string).to \
+          include('correlation_id: "cafef00d-cafe-cafe-cafe-cafef00dcafe"')
+      end
+    end
+  end
+end

--- a/spec/railway_ipc/publisher_spec.rb
+++ b/spec/railway_ipc/publisher_spec.rb
@@ -47,22 +47,12 @@ RSpec.describe RailwayIpc::SingletonPublisher do
     publisher.publish(message)
   end
 
-  context 'with alternate logger' do
-    around do |example|
-      original_logger = RailwayIpc.logger.logger
-      example.run
-      RailwayIpc.configure(logger: original_logger)
-    end
+  it 'warns of call to old #publish method' do
+    expect(RailwayIpc.logger).to \
+      receive(:warn).with('DEPRECATED: Use new PublisherInstance class')
 
-    it 'warns of call to old #publish method' do
-      logger_spy = instance_double(Logger, info: nil)
-      expect(logger_spy).to \
-        receive(:warn).with('DEPRECATED: Use new PublisherInstance class')
-
-      RailwayIpc.configure(logger: logger_spy)
-      allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything)
-      publisher.publish(message)
-    end
+    allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything)
+    publisher.publish(message)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ end
 
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
-RailwayIpc.configure(logger: Logger.new(IO::NULL))
+RailwayIpc.configure(IO::NULL)
 Sneakers.logger = Logger.new(IO::NULL)
 
 RSpec.configure do |config|


### PR DESCRIPTION
* switch interface to match standard Logger (i.e. `logger.info('my message', { some: 'object' })`); remove extraneous methods like `log_exception`
* instead of accepting an entire Logger object when configuring, take `device`, `level`, and `formatter`; this cleans up the interface
* clean up all logger call sites to use new interface