### PR TITLE
General logging improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* Internal log messages now include a `feature` key. This can be used by logging aggregator tools to group log messages across different systems that use the gem.
-* Internal log messages now log protobufs as a sub-hash which contains both the protobuf type and payload.
+* Several additions to internal logging:
+  - Log messages now include a `feature` key. This can be used by logging aggregator tools to group log messages across different systems that use the gem. If one isn't provided a default value of `railway_ipc` is used.
+  - Protobufs are logged as a sub-hash which contains both the protobuf type and payload.
+  - Exchange and queue names are logged where applicable.
+  - The internal Bunny connection now uses the `RailwayIpc::Logger` instead of a generic `Logger`.
 
 ### Changed
 * `RailwayIpc.configure` now takes `device`, `level`, and `formatter` instead of a complete `Logger` instance. The instance is now managed internally by Railway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+* Internal log messages now include a `feature` key. This can be used by logging aggregator tools to group log messages across different systems that use the gem.
+* Internal log messages now log protobufs as a sub-hash which contains both the protobuf type and payload.
+
 ### Changed
 * `RailwayIpc.configure` now takes `device`, `level`, and `formatter` instead of a complete `Logger` instance. The instance is now managed internally by Railway.
 

--- a/lib/railway_ipc.rb
+++ b/lib/railway_ipc.rb
@@ -37,10 +37,6 @@ module RailwayIpc
     @logger || RailwayIpc::Logger.new(STDOUT)
   end
 
-  def self.bunny_logger
-    logger
-  end
-
   def self.bunny_connection
     @bunny_connection ||= RailwayIpc::Rabbitmq::Adapter.new(
       exchange_name: 'default',

--- a/lib/railway_ipc/consumer/consumer.rb
+++ b/lib/railway_ipc/consumer/consumer.rb
@@ -46,7 +46,7 @@ module RailwayIpc
     rescue StandardError => e
       RailwayIpc.logger.error(
         e.message,
-        feature: 'railway_consumer',
+        feature: 'railway_ipc_consumer',
         error: e.class,
         payload: payload
       )

--- a/lib/railway_ipc/consumer/consumer.rb
+++ b/lib/railway_ipc/consumer/consumer.rb
@@ -47,6 +47,8 @@ module RailwayIpc
       RailwayIpc.logger.error(
         e.message,
         feature: 'railway_ipc_consumer',
+        exchange: exchange_name,
+        queue: queue_name,
         error: e.class,
         payload: payload
       )

--- a/lib/railway_ipc/consumer/process_incoming_message.rb
+++ b/lib/railway_ipc/consumer/process_incoming_message.rb
@@ -86,6 +86,8 @@ module RailwayIpc
       logger.error(
         error,
         feature: 'railway_ipc_consumer',
+        exchange: consumer.exchange_name,
+        queue: consumer.queue_name,
         protobuf: { type: incoming_message.class, data: incoming_message.decoded }
       )
       raise RailwayIpc::IncomingMessage::InvalidMessage.new(error)

--- a/lib/railway_ipc/consumer/process_incoming_message.rb
+++ b/lib/railway_ipc/consumer/process_incoming_message.rb
@@ -17,7 +17,8 @@ module RailwayIpc
       def run
         logger.warn(
           "Ignoring unknown message of type '#{incoming_message.type}'",
-          protobuf: incoming_message.decoded
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: incoming_message.type, data: incoming_message.decoded }
         )
       end
     end
@@ -37,7 +38,8 @@ module RailwayIpc
       def run
         logger.warn(
           "Ignoring message, no registered handler for '#{incoming_message.type}'",
-          protobuf: incoming_message.decoded
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: incoming_message.type, data: incoming_message.decoded }
         )
       end
     end
@@ -81,7 +83,11 @@ module RailwayIpc
 
     def raise_message_invalid_error
       error = "Message is invalid: #{incoming_message.stringify_errors}."
-      logger.error(error, protobuf: incoming_message.decoded)
+      logger.error(
+        error,
+        feature: 'railway_ipc_consumer',
+        protobuf: { type: incoming_message.class, data: incoming_message.decoded }
+      )
       raise RailwayIpc::IncomingMessage::InvalidMessage.new(error)
     end
 

--- a/lib/railway_ipc/handler.rb
+++ b/lib/railway_ipc/handler.rb
@@ -11,15 +11,27 @@ module RailwayIpc
     end
 
     def handle(message)
-      RailwayIpc.logger.info('Handling message', protobuf: message)
+      RailwayIpc.logger.info('Handling message', log_message_options(message))
       response = self.class.block.call(message)
       if response.success?
-        RailwayIpc.logger.info('Successfully handled message', protobuf: message)
+        RailwayIpc.logger.info('Successfully handled message', log_message_options(message))
       else
-        RailwayIpc.logger.error('Failed to handle message', protobuf: message)
+        RailwayIpc.logger.error('Failed to handle message', log_message_options(message))
       end
 
       response
+    end
+
+    private
+
+    def log_message_options(message)
+      {
+        feature: 'railway_ipc_consumer',
+        protobuf: {
+          type: message.class.name,
+          data: message
+        }
+      }
     end
   end
 end

--- a/lib/railway_ipc/logger.rb
+++ b/lib/railway_ipc/logger.rb
@@ -29,6 +29,7 @@ module RailwayIpc
 
     %w[fatal error warn info debug].each do |level|
       define_method(level) do |message, data={}|
+        data.merge!(feature: 'railway_ipc') unless data.key?(:feature)
         logger.send(level, data.merge(message: message))
       end
     end

--- a/lib/railway_ipc/publisher.rb
+++ b/lib/railway_ipc/publisher.rb
@@ -46,7 +46,7 @@ module RailwayIpc
     end
 
     def log_message_options(message=nil)
-      options = { feature: 'railway_ipc_publisher' }
+      options = { feature: 'railway_ipc_publisher', exchange: self.class.exchange_name }
       message.nil? ? options : options.merge(protobuf: { type: message.class, data: message })
     end
   end
@@ -93,6 +93,7 @@ module RailwayIpc
     def log_message_options(message)
       {
         feature: 'railway_ipc_publisher',
+        exchange: exchange_name,
         protobuf: {
           type: message.class,
           data: message

--- a/lib/railway_ipc/rabbitmq/adapter.rb
+++ b/lib/railway_ipc/rabbitmq/adapter.rb
@@ -28,7 +28,7 @@ module RailwayIpc
           port: settings[:port],
           vhost: vhost,
           automatic_recovery: false,
-          logger: RailwayIpc.bunny_logger
+          logger: RailwayIpc.logger
         }.merge(options))
       end
 

--- a/lib/railway_ipc/responder.rb
+++ b/lib/railway_ipc/responder.rb
@@ -11,7 +11,11 @@ module RailwayIpc
     end
 
     def respond(request)
-      RailwayIpc.logger.info('Responding to request', request: request)
+      RailwayIpc.logger.info(
+        'Responding to request',
+        protobuf: { type: request.class, data: request },
+        feature: 'railway_ipc_request'
+      )
       response = self.class.block.call(request)
       raise ResponseTypeError.new(response.class) unless response.is_a?(Google::Protobuf::MessageExts)
 

--- a/lib/railway_ipc/rpc/client/client.rb
+++ b/lib/railway_ipc/rpc/client/client.rb
@@ -39,6 +39,7 @@ module RailwayIpc
     end
 
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def process_payload(response)
       decoded_payload = decode_payload(response)
       case decoded_payload.type
@@ -47,6 +48,8 @@ module RailwayIpc
         RailwayIpc.logger.info(
           'Handling response',
           feature: 'railway_ipc_consumer',
+          exchange: self.class.exchange_name,
+          queue: self.class.queue_name,
           protobuf: { type: message.class, data: message }
         )
         RailwayIpc::Response.new(message, success: true)
@@ -55,6 +58,7 @@ module RailwayIpc
         raise RailwayIpc::UnhandledMessageError.new("#{self.class} does not know how to handle #{decoded_payload.type}")
       end
     end
+    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
 
     def setup_rabbit_connection
@@ -85,6 +89,8 @@ module RailwayIpc
       RailwayIpc.logger.error(
         exception.message,
         feature: 'railway_ipc_consumer',
+        exchange: self.class.exchange_name,
+        queue: self.class.queue_name,
         error: exception.class,
         payload: decode_for_error(exception, payload)
       )
@@ -106,6 +112,7 @@ module RailwayIpc
       RailwayIpc.logger.info(
         'Sending request',
         feature: 'railway_ipc_publisher',
+        exchange: self.class.exchange_name,
         protobuf: { type: request_message.class, data: request_message }
       )
       rabbit_connection.publish(RailwayIpc::Rabbitmq::Payload.encode(request_message), routing_key: '')

--- a/lib/railway_ipc/rpc/client/client.rb
+++ b/lib/railway_ipc/rpc/client/client.rb
@@ -44,7 +44,11 @@ module RailwayIpc
       case decoded_payload.type
       when *registered_handlers
         @message = get_message_class(decoded_payload).decode(decoded_payload.message)
-        RailwayIpc.logger.info('Handling response', protobuf: message)
+        RailwayIpc.logger.info(
+          'Handling response',
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: message.class, data: message }
+        )
         RailwayIpc::Response.new(message, success: true)
       else
         @message = LearnIpc::ErrorMessage.decode(decoded_payload.message)
@@ -99,7 +103,11 @@ module RailwayIpc
     end
 
     def publish_message
-      RailwayIpc.logger.info('Sending request', request_message: request_message)
+      RailwayIpc.logger.info(
+        'Sending request',
+        feature: 'railway_ipc_publisher',
+        protobuf: { type: request_message.class, data: request_message }
+      )
       rabbit_connection.publish(RailwayIpc::Rabbitmq::Payload.encode(request_message), routing_key: '')
     end
 

--- a/lib/railway_ipc/rpc/client/client.rb
+++ b/lib/railway_ipc/rpc/client/client.rb
@@ -80,7 +80,7 @@ module RailwayIpc
     def log_exception(exception, payload)
       RailwayIpc.logger.error(
         exception.message,
-        feature: 'railway_consumer',
+        feature: 'railway_ipc_consumer',
         error: exception.class,
         payload: decode_for_error(exception, payload)
       )

--- a/lib/railway_ipc/rpc/server/server.rb
+++ b/lib/railway_ipc/rpc/server/server.rb
@@ -59,7 +59,12 @@ module RailwayIpc
     def handle_request(payload)
       response = work(payload)
     rescue StandardError => e
-      RailwayIpc.logger.error("Error responding to message. Error: #{e.class}, #{e.message}", protobuf: message)
+      RailwayIpc.logger.error(
+        'Error responding to message.',
+        exception: e,
+        feature: 'railway_ipc_consumer',
+        protobuf: { type: message.class, data: message }
+      )
       response = self.class.rpc_error_adapter_class.error_message(e, message)
     ensure
       if response

--- a/lib/railway_ipc/rpc/server/server.rb
+++ b/lib/railway_ipc/rpc/server/server.rb
@@ -48,6 +48,8 @@ module RailwayIpc
       RailwayIpc.logger.error(
         e.message,
         feature: 'railway_ipc_consumer',
+        exchange: self.class.exchange_name,
+        queue: self.class.queue_name,
         error: e.class,
         payload: payload
       )
@@ -56,6 +58,8 @@ module RailwayIpc
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def handle_request(payload)
       response = work(payload)
     rescue StandardError => e
@@ -63,6 +67,8 @@ module RailwayIpc
         'Error responding to message.',
         exception: e,
         feature: 'railway_ipc_consumer',
+        exchange: self.class.exchange_name,
+        queue: self.class.queue_name,
         protobuf: { type: message.class, data: message }
       )
       response = self.class.rpc_error_adapter_class.error_message(e, message)
@@ -73,6 +79,8 @@ module RailwayIpc
         )
       end
     end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/lib/railway_ipc/rpc/server/server.rb
+++ b/lib/railway_ipc/rpc/server/server.rb
@@ -47,7 +47,7 @@ module RailwayIpc
     rescue StandardError => e
       RailwayIpc.logger.error(
         e.message,
-        feature: 'railway_consumer',
+        feature: 'railway_ipc_consumer',
         error: e.class,
         payload: payload
       )

--- a/spec/railway_ipc/consumer/process_incoming_message_spec.rb
+++ b/spec/railway_ipc/consumer/process_incoming_message_spec.rb
@@ -129,7 +129,11 @@ RSpec.describe RailwayIpc::ProcessIncomingMessage, '#call' do
         )
 
         expect(RailwayIpc.logger).to \
-          receive(:warn).with("Ignoring message, no registered handler for 'RailwayIpc::Messages::TestMessage'", protobuf: incoming_message.decoded)
+          receive(:warn).with(
+            "Ignoring message, no registered handler for 'RailwayIpc::Messages::TestMessage'",
+            feature: 'railway_ipc_consumer',
+            protobuf: { type: 'RailwayIpc::Messages::TestMessage', data: incoming_message.decoded }
+          )
 
         process = described_class.new(consumer, incoming_message)
         process.call
@@ -161,7 +165,7 @@ RSpec.describe RailwayIpc::ProcessIncomingMessage, '#call' do
       expect(consumed_message.encoded_message).to eq(payload)
     end
 
-    it 'logs an warning' do
+    it 'logs a warning' do
       consumer = instance_double(
         RailwayIpc::Consumer,
         queue_name: 'my-queue',
@@ -176,7 +180,11 @@ RSpec.describe RailwayIpc::ProcessIncomingMessage, '#call' do
 
       incoming_message = RailwayIpc::IncomingMessage.new(payload)
       expect(RailwayIpc.logger).to \
-        receive(:warn).with("Ignoring unknown message of type 'Foo'", protobuf: incoming_message.decoded)
+        receive(:warn).with(
+          "Ignoring unknown message of type 'Foo'",
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: 'Foo', data: incoming_message.decoded }
+        )
 
       process = described_class.new(consumer, incoming_message)
       process.call

--- a/spec/railway_ipc/consumer/process_incoming_message_spec.rb
+++ b/spec/railway_ipc/consumer/process_incoming_message_spec.rb
@@ -193,7 +193,11 @@ RSpec.describe RailwayIpc::ProcessIncomingMessage, '#call' do
 
   context 'when the incoming message is invalid (ie. missing correlation ID)' do
     it 'raises an error and does not store message' do
-      consumer = instance_double(RailwayIpc::Consumer)
+      consumer = instance_double(
+        RailwayIpc::Consumer,
+        queue_name: 'my-queue',
+        exchange_name: 'my-exchange'
+      )
 
       payload = {
         type: 'RailwayIpc::Messages::TestMessage',

--- a/spec/railway_ipc/consumer_spec.rb
+++ b/spec/railway_ipc/consumer_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe RailwayIpc::Consumer, '#work' do
           {
             feature: 'railway_ipc_consumer',
             error: StandardError,
+            exchange: 'test:events',
+            queue: 'ironboard:test:commands',
             payload: stubbed_payload
           }
         )

--- a/spec/railway_ipc/consumer_spec.rb
+++ b/spec/railway_ipc/consumer_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe RailwayIpc::Consumer, '#work' do
         receive(:error).with(
           'StandardError',
           {
-            feature: 'railway_consumer',
+            feature: 'railway_ipc_consumer',
             error: StandardError,
             payload: stubbed_payload
           }

--- a/spec/railway_ipc/handler_spec.rb
+++ b/spec/railway_ipc/handler_spec.rb
@@ -7,10 +7,18 @@ RSpec.describe RailwayIpc::Handler do
   context 'when the message is handled successfully' do
     it 'logs the message was successful' do
       expect(RailwayIpc.logger).to \
-        receive(:info).with('Handling message', protobuf: message)
+        receive(:info).with(
+          'Handling message',
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: 'RailwayIpc::Messages::TestMessage', data: message }
+        )
 
       expect(RailwayIpc.logger).to \
-        receive(:info).with('Successfully handled message', protobuf: message)
+        receive(:info).with(
+          'Successfully handled message',
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: 'RailwayIpc::Messages::TestMessage', data: message }
+        )
 
       handler.handle(message)
     end
@@ -25,10 +33,18 @@ RSpec.describe RailwayIpc::Handler do
 
     it 'logs the message failed' do
       expect(RailwayIpc.logger).to \
-        receive(:info).with('Handling message', protobuf: message)
+        receive(:info).with(
+          'Handling message',
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: 'RailwayIpc::Messages::TestMessage', data: message }
+        )
 
       expect(RailwayIpc.logger).to \
-        receive(:error).with('Failed to handle message', protobuf: message)
+        receive(:error).with(
+          'Failed to handle message',
+          feature: 'railway_ipc_consumer',
+          protobuf: { type: 'RailwayIpc::Messages::TestMessage', data: message }
+        )
 
       handler.handle(message)
     end

--- a/spec/railway_ipc/logger_spec.rb
+++ b/spec/railway_ipc/logger_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 %w[fatal error warn info debug].each do |level|
   RSpec.describe RailwayIpc::Logger, "##{level}" do
     let(:io) { StringIO.new }
@@ -14,10 +15,17 @@ require 'spec_helper'
 
       it { expect(io.string).to include(level.upcase) }
       it { expect(io.string).to include('some message') }
+
+      it 'logs a default `feature` key' do
+        expect(io.string).to include(':feature=>"railway_ipc"')
+      end
     end
 
     context 'when extra data is provided' do
-      before(:each) { subject.send(level, 'some message', protobuf: stubbed_protobuf) }
+      before(:each) do
+        kwargs = { protobuf: stubbed_protobuf, feature: 'example' }
+        subject.send(level, 'some message', **kwargs)
+      end
 
       it { expect(io.string).to include(level.upcase) }
       it { expect(io.string).to include('some message') }
@@ -26,6 +34,18 @@ require 'spec_helper'
         expect(io.string).to \
           include('correlation_id: "cafef00d-cafe-cafe-cafe-cafef00dcafe"')
       end
+
+      it 'allows a `feature` key to be set' do
+        expect(io.string).to include(':feature=>"example"')
+      end
+
+      context 'and the `feature` key is not provided' do
+        it 'logs a default `feature` key' do
+          subject.send(level, 'some message', protobuf: stubbed_protobuf)
+          expect(io.string).to include(':feature=>"railway_ipc"')
+        end
+      end
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/railway_ipc/publisher_spec.rb
+++ b/spec/railway_ipc/publisher_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe RailwayIpc::SingletonPublisher do
     expect(RailwayIpc.logger).to \
       receive(:warn).with(
         'DEPRECATED: Use new PublisherInstance class',
+        exchange: 'test:events',
         feature: 'railway_ipc_publisher'
       )
 

--- a/spec/railway_ipc/publisher_spec.rb
+++ b/spec/railway_ipc/publisher_spec.rb
@@ -49,7 +49,10 @@ RSpec.describe RailwayIpc::SingletonPublisher do
 
   it 'warns of call to old #publish method' do
     expect(RailwayIpc.logger).to \
-      receive(:warn).with('DEPRECATED: Use new PublisherInstance class')
+      receive(:warn).with(
+        'DEPRECATED: Use new PublisherInstance class',
+        feature: 'railway_ipc_publisher'
+      )
 
     allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything)
     publisher.publish(message)


### PR DESCRIPTION
* Log exchange and queue names where applicable

* Ensure all log messages are formatted correctly
   - each log message should have a `feature` key
   - when logging protobufs, use a sub-hash that contains the protobuf type and the decoded data

* Remove `bunny_logger` class method -- The RabbitMQ adapter can use Railway's logger directly now, since it conforms to the standard `Logger` interface.

* Provide a default `feature` when logging -- If a `feature` key is not provided, add a default one with the value of 'railway_ipc'. In practice, all log statements should provide a `feature` key.

* Update feature name when logging -- Use 'railway_ipc_consumer' instead of 'railway_consumer' to be consistent with the Elixir version of Railway. This allows logs across different applications to be associated by feature.