### PR TITLE
Fix `RailwayIpc::Logger` so that it can handle blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+* `RailwayIpc::Logger` now handles block syntax (i.e. `logger.info { 'my message' }`) correctly.
 
 ## [2.0.0] - 2020-08-20
 ### Added

--- a/spec/railway_ipc/logger_spec.rb
+++ b/spec/railway_ipc/logger_spec.rb
@@ -14,10 +14,55 @@ require 'spec_helper'
       before(:each) { subject.send(level, 'some message') }
 
       it { expect(io.string).to include(level.upcase) }
-      it { expect(io.string).to include('some message') }
+      it { expect(io.string).to include(':message=>"some message"') }
+      it { expect(io.string).to_not include(':progname') }
 
       it 'logs a default `feature` key' do
         expect(io.string).to include(':feature=>"railway_ipc"')
+      end
+
+      context 'and a block is given' do
+        before(:each) { subject.send(level, 'some_message') { 'message in a block' } }
+
+        it { expect(io.string).to include(level.upcase) }
+        it { expect(io.string).to include(':message=>"message in a block"') }
+
+        it 'logs a default `feature` key' do
+          expect(io.string).to include(':feature=>"railway_ipc"')
+        end
+
+        it 'sets the given message as the progname' do
+          expect(io.string).to include(':progname=>"some_message"')
+        end
+      end
+    end
+
+    context 'when there is no message' do
+      context 'and a block is given' do
+        before(:each) { subject.send(level) { 'message in a block' } }
+
+        it { expect(io.string).to include(level.upcase) }
+        it { expect(io.string).to include(':message=>"message in a block"') }
+        it { expect(io.string).to_not include(':progname') }
+
+        it 'logs a default `feature` key' do
+          expect(io.string).to include(':feature=>"railway_ipc"')
+        end
+      end
+
+      context 'and no block is given' do
+        before(:each) { subject.send(level) }
+
+        it { expect(io.string).to include(level.upcase) }
+        it { expect(io.string).to include(':message=>nil') }
+
+        it 'does not add a `progname`' do
+          expect(io.string).to_not include(':progname')
+        end
+
+        it 'logs a default `feature` key' do
+          expect(io.string).to include(':feature=>"railway_ipc"')
+        end
       end
     end
 
@@ -28,7 +73,8 @@ require 'spec_helper'
       end
 
       it { expect(io.string).to include(level.upcase) }
-      it { expect(io.string).to include('some message') }
+      it { expect(io.string).to include(':message=>"some message"') }
+      it { expect(io.string).to_not include(':progname') }
 
       it 'includes the data in the output' do
         expect(io.string).to \
@@ -43,6 +89,33 @@ require 'spec_helper'
         it 'logs a default `feature` key' do
           subject.send(level, 'some message', protobuf: stubbed_protobuf)
           expect(io.string).to include(':feature=>"railway_ipc"')
+        end
+      end
+
+      context 'and a block is given' do
+        before(:each) do
+          kwargs = { protobuf: stubbed_protobuf, feature: 'example' }
+          subject.send(level, **kwargs) { 'message in a block' }
+        end
+
+        it { expect(io.string).to include(level.upcase) }
+        it { expect(io.string).to include(':message=>"message in a block"') }
+        it { expect(io.string).to_not include(':progname') }
+
+        it 'includes the data in the output' do
+          expect(io.string).to \
+            include('correlation_id: "cafef00d-cafe-cafe-cafe-cafef00dcafe"')
+        end
+
+        it 'allows a `feature` key to be set' do
+          expect(io.string).to include(':feature=>"example"')
+        end
+
+        context 'and the `feature` key is not provided' do
+          it 'logs a default `feature` key' do
+            subject.send(level, protobuf: stubbed_protobuf) { 'message in a block' }
+            expect(io.string).to include(':feature=>"railway_ipc"')
+          end
         end
       end
     end


### PR DESCRIPTION
This should fix the intermittent [errors] we're seeing for Ironboard & Easely. The logger wasn't handling block syntax. Slack [thread] for context.

[errors]: https://flatironlabs.airbrake.io/projects/259023/groups/2815780662902848665?tab=notice-detail
[thread]: https://flatiron-staff.slack.com/archives/C01109BSPRU/p1597971222000100