### PR TITLE
Don't log queue name in RPC client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+* RPC `RailwayIpc::Client` does not need to log the queue name.
 ### Removed
 ### Fixed
 

--- a/lib/railway_ipc/rpc/client/client.rb
+++ b/lib/railway_ipc/rpc/client/client.rb
@@ -39,7 +39,6 @@ module RailwayIpc
     end
 
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def process_payload(response)
       decoded_payload = decode_payload(response)
       case decoded_payload.type
@@ -49,7 +48,6 @@ module RailwayIpc
           'Handling response',
           feature: 'railway_ipc_consumer',
           exchange: self.class.exchange_name,
-          queue: self.class.queue_name,
           protobuf: { type: message.class, data: message }
         )
         RailwayIpc::Response.new(message, success: true)
@@ -58,7 +56,6 @@ module RailwayIpc
         raise RailwayIpc::UnhandledMessageError.new("#{self.class} does not know how to handle #{decoded_payload.type}")
       end
     end
-    # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
 
     def setup_rabbit_connection
@@ -90,7 +87,6 @@ module RailwayIpc
         exception.message,
         feature: 'railway_ipc_consumer',
         exchange: self.class.exchange_name,
-        queue: self.class.queue_name,
         error: exception.class,
         payload: decode_for_error(exception, payload)
       )


### PR DESCRIPTION
There's no need to log the queue name, and in some cases it may not be available.