### PR TITLE
Fix RPC server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+* Fix RPC server. RPC servers need to conform to the Sneaker worker API (i.e. their initializers need to be able to accept queue name / pool and they require a `stop` method.
 
 ## [2.0.2] - 2020-08-27
 ### Changed

--- a/lib/railway_ipc/rpc/server/server.rb
+++ b/lib/railway_ipc/rpc/server/server.rb
@@ -14,7 +14,7 @@ module RailwayIpc
       RailwayIpc::RPC::ServerResponseHandlers.instance.register(handler: with, message: message_type)
     end
 
-    def initialize(opts={ automatic_recovery: true }, rabbit_adapter: RailwayIpc::Rabbitmq::Adapter)
+    def initialize(_queue, _pool, opts={ automatic_recovery: true }, rabbit_adapter: RailwayIpc::Rabbitmq::Adapter)
       @rabbit_connection = rabbit_adapter.new(
         queue_name: self.class.queue_name,
         exchange_name: self.class.exchange_name,
@@ -29,6 +29,10 @@ module RailwayIpc
         .create_queue(durable: true)
         .bind_queue_to_exchange
       subscribe_to_queue
+    end
+
+    def stop
+      rabbit_connection.disconnect
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/spec/integration/request_response_spec.rb
+++ b/spec/integration/request_response_spec.rb
@@ -4,7 +4,7 @@ require_relative './i_spec.rb'
 
 RSpec.describe 'Request Response Cycle' do
   before do
-    server = RailwayIpc::TestServer.new
+    server = RailwayIpc::TestServer.new(nil, nil)
     server.run
   end
 

--- a/spec/railway_ipc/server_spec.rb
+++ b/spec/railway_ipc/server_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RailwayIpc::Server do
     let(:connection) { double('connection', { start: true, create_channel: channel }) }
 
     before do
-      @server = RailwayIpc::TestServer.new
+      @server = RailwayIpc::TestServer.new(nil, nil)
     end
     context 'when the server does not know how to handle the message' do
       let(:message)   { LearnIpc::Requests::UnhandledRequest.new(user_uuid: '1234', correlation_id: '1234', reply_to: 'queue_name') }


### PR DESCRIPTION
RPC servers need to conform to the Sneaker worker API (i.e. their initializers need to be able to accept queue name / pool and they require a `stop` method. For our purposes, the queue and pool arguments are never used since they're provided by other means.