### PR TITLE
Allow configuration of `from_queue` options via `listen_to`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            gem install bundler:2.0.1
+            gem install bundler:2.1.4
             bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           paths:

--- a/lib/railway_ipc/consumer/consumer.rb
+++ b/lib/railway_ipc/consumer/consumer.rb
@@ -3,6 +3,7 @@
 module RailwayIpc
   class Consumer
     include Sneakers::Worker
+
     def self.inherited(base)
       base.instance_eval do
         def handlers
@@ -11,12 +12,13 @@ module RailwayIpc
       end
     end
 
-    def self.listen_to(queue:, exchange:)
-      from_queue queue,
-                 exchange: exchange,
-                 durable: true,
-                 exchange_type: :fanout,
-                 connection: RailwayIpc.bunny_connection
+    def self.listen_to(queue:, exchange:, options: {})
+      from_queue queue, {
+        exchange: exchange,
+        durable: true,
+        exchange_type: :fanout,
+        connection: RailwayIpc.bunny_connection
+      }.merge(options)
     end
 
     def self.handle(message_type, with:)

--- a/lib/railway_ipc/rpc/concerns/message_observation_configurable.rb
+++ b/lib/railway_ipc/rpc/concerns/message_observation_configurable.rb
@@ -3,7 +3,7 @@
 module RailwayIpc
   module RPC
     module MessageObservationConfigurable
-      def listen_to(exchange:, queue:)
+      def listen_to(queue:, exchange:)
         @exchange_name = exchange
         @queue_name = queue
       end

--- a/lib/railway_ipc/version.rb
+++ b/lib/railway_ipc/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailwayIpc
-  VERSION = '2.0.3'
+  VERSION = '2.1.0'
 end

--- a/railway_ipc.gemspec
+++ b/railway_ipc.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '2.0.1'
+  spec.add_development_dependency 'bundler', '2.1.4'
   spec.add_development_dependency 'factory_bot', '~> 5.1'
   spec.add_development_dependency 'google-protobuf', '~> 3.9'
   spec.add_development_dependency 'rake', '>= 10.0.0'

--- a/spec/railway_ipc/consumer_spec.rb
+++ b/spec/railway_ipc/consumer_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe RailwayIpc::Consumer, '.listen_to' do
       expect(RailwayIpc::TestConsumer)
         .to receive(:from_queue)
         .with('test_queue', {
-                              exchange: 'test_exchange',
-                              durable: true,
-                              exchange_type: :fanout,
-                              connection: RailwayIpc.bunny_connection
-                            })
+                exchange: 'test_exchange',
+                durable: true,
+                exchange_type: :fanout,
+                connection: RailwayIpc.bunny_connection
+              })
 
       RailwayIpc::TestConsumer.listen_to(queue: 'test_queue', exchange: 'test_exchange')
     end
@@ -21,11 +21,11 @@ RSpec.describe RailwayIpc::Consumer, '.listen_to' do
       expect(RailwayIpc::TestConsumer)
         .to receive(:from_queue)
         .with('test_queue', {
-                              exchange: 'test_exchange',
-                              durable: false,
-                              exchange_type: :fanout,
-                              connection: RailwayIpc.bunny_connection
-                            })
+                exchange: 'test_exchange',
+                durable: false,
+                exchange_type: :fanout,
+                connection: RailwayIpc.bunny_connection
+              })
 
       RailwayIpc::TestConsumer.listen_to(
         queue: 'test_queue',

--- a/spec/railway_ipc/consumer_spec.rb
+++ b/spec/railway_ipc/consumer_spec.rb
@@ -1,14 +1,40 @@
 # frozen_string_literal: true
 
 RSpec.describe RailwayIpc::Consumer, '.listen_to' do
-  it 'specifies the queue and exchange' do
-    expect(RailwayIpc::TestConsumer).to receive(:from_queue).with('test_queue', {
-                                                                    exchange: 'test_exchange',
-                                                                    durable: true,
-                                                                    exchange_type: :fanout,
-                                                                    connection: RailwayIpc.bunny_connection
-                                                                  })
-    RailwayIpc::TestConsumer.listen_to(queue: 'test_queue', exchange: 'test_exchange')
+  context 'default options' do
+    it 'specifies the queue and exchange' do
+      expect(RailwayIpc::TestConsumer)
+        .to receive(:from_queue)
+        .with('test_queue', {
+                              exchange: 'test_exchange',
+                              durable: true,
+                              exchange_type: :fanout,
+                              connection: RailwayIpc.bunny_connection
+                            })
+
+      RailwayIpc::TestConsumer.listen_to(queue: 'test_queue', exchange: 'test_exchange')
+    end
+  end
+
+  context 'custom options' do
+    it 'merges additional options for .from_queue' do
+      expect(RailwayIpc::TestConsumer)
+        .to receive(:from_queue)
+        .with('test_queue', {
+                              exchange: 'test_exchange',
+                              durable: false,
+                              exchange_type: :fanout,
+                              connection: RailwayIpc.bunny_connection
+                            })
+
+      RailwayIpc::TestConsumer.listen_to(
+        queue: 'test_queue',
+        exchange: 'test_exchange',
+        options: {
+          durable: false
+        }
+      )
+    end
   end
 end
 

--- a/spec/support/rails_app/Gemfile.lock
+++ b/spec/support/rails_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    railway-ipc (1.0.1)
+    railway-ipc (2.1.0)
       bunny (~> 2.2.0)
       sneakers (~> 2.3.5)
 


### PR DESCRIPTION
- New (optional) param:
```ruby
RailwayIpc::TestConsumer.listen_to(
  queue: 'test_queue',
  exchange: 'test_exchange',
  options: {
    durable: false
  }
)
```

- Changed the ordering of `:queue` and `:exchange` in `RailwayIpc::RPC::MessageObservationConfigurable` to match `RailwayIpc::Consumer`