### PR TITLE
Consumer logic for deciding which decoder to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+* (Breaking Change) Rename `Consumer#work` to `Consumer#work_with_params`. This
+  was necessary so that we can support specifying different message encodings via metadata in the future. If the message encoding cannot be determined from the message matadata fall back to a default decoder (binary protobufs).
+
 ### Removed
 ### Fixed
 

--- a/spec/railway_ipc/consumer_spec.rb
+++ b/spec/railway_ipc/consumer_spec.rb
@@ -78,17 +78,23 @@ RSpec.describe RailwayIpc::Consumer, '.handle' do
   end
 end
 
-RSpec.describe RailwayIpc::Consumer, '#work' do
+RSpec.describe RailwayIpc::Consumer, '#work_with_params' do
+  let(:delivery_info) { instance_double(Bunny::DeliveryInfo) }
+  let(:metadata) { {} }
+
   it 'processes the message' do
     consumer = RailwayIpc::TestConsumer.new
     expect {
-      consumer.work(stubbed_pb_binary_payload)
+      consumer.work_with_params(stubbed_pb_binary_payload, delivery_info, metadata)
     }.to change { RailwayIpc::ConsumedMessage.count }.by(1)
   end
 
   it 'acknowledges the message' do
     consumer = RailwayIpc::TestConsumer.new
-    expect(consumer.work(stubbed_pb_binary_payload)).to eq(:ack)
+    result = \
+      consumer.work_with_params(stubbed_pb_binary_payload, delivery_info, metadata)
+
+    expect(result).to eq(:ack)
   end
 
   context 'when an error occurs' do
@@ -112,11 +118,14 @@ RSpec.describe RailwayIpc::Consumer, '#work' do
           }
         )
 
-      consumer.work(stubbed_pb_binary_payload)
+      consumer.work_with_params(stubbed_pb_binary_payload, delivery_info, metadata)
     end
 
     it 'rejects the message' do
-      expect(consumer.work(stubbed_pb_binary_payload)).to eq(:reject)
+      result = \
+        consumer.work_with_params(stubbed_pb_binary_payload, delivery_info, metadata)
+
+      expect(result).to eq(:reject)
     end
   end
 end


### PR DESCRIPTION
Consumers now check the message metadata for a message encoding type which is used to decode the message. If one cannot be found, it falls back to assuming the message is a Base64 encoded binary protobuf. This allows us to support other formats in the future (i.e. JSON) without breaking existing message contracts.

This does introduce a public API breaking change, however. The `Consumer#work` method was renamed to `Consumer#work_with_params` in order to get access to the message metadata. Any clients that override the `Consumer#work` method will now need to override the `Consumer#work_with_params` method instead.