### PR TITLE
Remove `SingletonPublisher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
 ### Changed
 ### Removed
+* Remove deprecated `SingletonPublisher`
+
 ### Fixed
 
 ## [4.0.1] - 2021-01-12

--- a/lib/railway_ipc/publisher.rb
+++ b/lib/railway_ipc/publisher.rb
@@ -1,56 +1,6 @@
 # frozen_string_literal: true
 
 module RailwayIpc
-  class SingletonPublisher < Sneakers::Publisher
-    include ::Singleton
-
-    def self.exchange(exchange)
-      @exchange_name = exchange
-    end
-
-    def self.exchange_name
-      raise 'Subclass must set the exchange' unless @exchange_name
-
-      @exchange_name
-    end
-
-    def initialize
-      super(exchange: self.class.exchange_name, exchange_type: :fanout)
-    end
-
-    def publish(message, published_message_store=RailwayIpc::PublishedMessage)
-      RailwayIpc.logger.warn('DEPRECATED: Use new PublisherInstance class', log_message_options)
-      ensure_message_uuid(message)
-      ensure_correlation_id(message)
-      RailwayIpc.logger.info('Publishing message', log_message_options(message))
-      result = super(RailwayIpc::Rabbitmq::Payload.encode(message))
-      published_message_store.store_message(self.class.exchange_name, message)
-      result
-    rescue RailwayIpc::InvalidProtobuf => e
-      RailwayIpc.logger.error('Invalid protobuf', log_message_options(message))
-      raise e
-    end
-
-    private
-
-    def ensure_message_uuid(message)
-      message.uuid = SecureRandom.uuid if message.uuid.blank?
-      message
-    end
-
-    def ensure_correlation_id(message)
-      message.correlation_id = SecureRandom.uuid if message.correlation_id.blank?
-      message
-    end
-
-    def log_message_options(message=nil)
-      options = { feature: 'railway_ipc_publisher', exchange: self.class.exchange_name }
-      message.nil? ? options : options.merge(protobuf: { type: message.class, data: message })
-    end
-  end
-end
-
-module RailwayIpc
   class Publisher
     attr_reader :exchange_name, :message_store
 

--- a/spec/railway_ipc/publisher_spec.rb
+++ b/spec/railway_ipc/publisher_spec.rb
@@ -2,64 +2,6 @@
 
 require 'timeout'
 
-RSpec.describe RailwayIpc::SingletonPublisher do
-  let(:publisher) { RailwayIpc::TestPublisher.instance }
-  let(:message)   do
-    RailwayIpc::Messages::TestMessage.new(
-      uuid: SecureRandom.uuid,
-      correlation_id: SecureRandom.uuid
-    )
-  end
-  let(:encoded_message) { Base64.encode64(RailwayIpc::Messages::TestMessage.encode(message)) }
-
-  it 'knows its exchange' do
-    expect(publisher.class.exchange_name).to eq('test:events')
-  end
-
-  it 'initializes the Sneakers publisher with the correct exchange and exchange type' do
-    expect(publisher.instance_variable_get(:@opts)[:exchange]).to eq('test:events')
-    expect(publisher.instance_variable_get(:@opts)[:exchange_options][:type]).to eq(:fanout)
-  end
-
-  it 'auto generates a message uuid if one is not passed in' do
-    message.uuid = ''
-    uuid = SecureRandom.uuid
-
-    message_with_uuid = message.clone
-    message_with_uuid.uuid = uuid
-
-    allow(SecureRandom).to receive(:uuid).and_return(uuid)
-    allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything)
-    expect(RailwayIpc::Rabbitmq::Payload).to receive(:encode).at_least(1).times.with(message_with_uuid).and_call_original
-    publisher.publish(message)
-  end
-
-  it 'auto generates a correlation_id if one is not passed in' do
-    message.correlation_id = ''
-    correlation_id = SecureRandom.uuid
-
-    message_with_correlation_id = message.clone
-    message_with_correlation_id.correlation_id = correlation_id
-
-    allow(SecureRandom).to receive(:uuid).and_return(correlation_id)
-    allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything)
-    expect(RailwayIpc::Rabbitmq::Payload).to receive(:encode).at_least(1).times.with(message_with_correlation_id).and_call_original
-    publisher.publish(message)
-  end
-
-  it 'warns of call to old #publish method' do
-    expect(RailwayIpc.logger).to \
-      receive(:warn).with(
-        'DEPRECATED: Use new PublisherInstance class',
-        exchange: 'test:events',
-        feature: 'railway_ipc_publisher'
-      )
-
-    allow_any_instance_of(Sneakers::Publisher).to receive(:publish).with(anything)
-    publisher.publish(message)
-  end
-end
-
 RSpec.describe RailwayIpc::Publisher, '#exchange' do
   after { cleanup! }
 

--- a/spec/support/test_publisher.rb
+++ b/spec/support/test_publisher.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module RailwayIpc
-  class TestPublisher < RailwayIpc::SingletonPublisher
-    exchange 'test:events'
+  class TestPublisher < RailwayIpc::Publisher
+    def initialize
+      super(exchange_name: 'test:events')
+    end
   end
 end


### PR DESCRIPTION
We deprecated `SingletonPublisher` a few releases ago. Our internal systems no longer use it, so let's remove it.