### PR TITLE
Add some specs for Protobuf contexts

### DIFF
--- a/spec/railway_ipc/message_encoders_spec.rb
+++ b/spec/railway_ipc/message_encoders_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RailwayIpc::MessageEncoders::ProtobufBinaryEncoder do
                '"encoded_message":"CiRiYWFkZjAwZC1iYWFkLWJhYWQtYmFhZC1i' \
                'YWFkYmFhZGYwMGQSJGNhZmVm\\nMDBkLWNhZmUtY2FmZS1jYWZlLWNh' \
                'ZmVmMDBkY2FmZRokZGVhZGJlZWYtZGVh\\nZC1kZWFkLWRlYWQtZGVh' \
-               'ZGRlYWZiZWVmKgQKAjQy\\n"}'
+               'ZGRlYWZiZWVmIg0KBHNvbWUSBXZhbHVlKgQKAjQy\\n"}'
 
     message = RailwayIpc::OutgoingMessage.new(stubbed_protobuf, 'test:events')
     expect(described_class.call(message)).to eq(expected)
@@ -26,7 +26,7 @@ RSpec.describe RailwayIpc::MessageEncoders::ProtobufJsonEncoder do
                '"user_uuid":"baadf00d-baad-baad-baad-baadbaadf00d",' \
                '"correlation_id":"cafef00d-cafe-cafe-cafe-cafef00dcafe",' \
                '"uuid":"deadbeef-dead-dead-dead-deaddeafbeef",' \
-               '"context":{},"data":{"param":"42"}}}'
+               '"context":{"some":"value"},"data":{"param":"42"}}}'
 
     message = RailwayIpc::OutgoingMessage.new(stubbed_protobuf, 'test:events')
     expect(described_class.call(message)).to eq(expected)

--- a/spec/railway_ipc/models/published_message_spec.rb
+++ b/spec/railway_ipc/models/published_message_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RailwayIpc::PublishedMessage, '.store_message', type: :model do
                          '"user_uuid":"baadf00d-baad-baad-baad-baadbaadf00d",' \
                          '"correlation_id":"cafef00d-cafe-cafe-cafe-cafef00dcafe",' \
                          '"uuid":"deadbeef-dead-dead-dead-deaddeafbeef",' \
-                         '"context":{},"data":{"param":"42"}}}'
+                         '"context":{"some":"value"},"data":{"param":"42"}}}'
 
       expect(stored_message.encoded_message).to eq(expected_encoded)
 

--- a/spec/railway_ipc/outgoing_message_spec.rb
+++ b/spec/railway_ipc/outgoing_message_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe RailwayIpc::OutgoingMessage, '#encoded' do
                '"encoded_message":"CiRiYWFkZjAwZC1iYWFkLWJhYWQtYmFhZC1i' \
                'YWFkYmFhZGYwMGQSJGNhZmVm\\nMDBkLWNhZmUtY2FmZS1jYWZlLWNh' \
                'ZmVmMDBkY2FmZRokZGVhZGJlZWYtZGVh\\nZC1kZWFkLWRlYWQtZGVh' \
-               'ZGRlYWZiZWVmKgQKAjQy\\n"}'
+               'ZGRlYWZiZWVmIg0KBHNvbWUSBXZhbHVlKgQKAjQy\\n"}'
 
     expect(subject.encoded).to eq(expected)
   end
@@ -65,7 +65,7 @@ RSpec.describe RailwayIpc::OutgoingMessage, '#encoded' do
                '"user_uuid":"baadf00d-baad-baad-baad-baadbaadf00d",' \
                '"correlation_id":"cafef00d-cafe-cafe-cafe-cafef00dcafe",' \
                '"uuid":"deadbeef-dead-dead-dead-deaddeafbeef",' \
-               '"context":{},"data":{"param":"42"}}}'
+               '"context":{"some":"value"},"data":{"param":"42"}}}'
 
     expect(subject.encoded).to eq(expected)
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -8,6 +8,7 @@ module RailwayIpc
 
     def stubbed_protobuf(uuid: DEAD_BEEF_UUID, user_uuid: BAAD_FOOD_UUID, correlation_id: CAFE_FOOD_UUID)
       RailwayIpc::Messages::TestMessage.new(
+        context: { 'some' => 'value' },
         uuid: uuid,
         user_uuid: user_uuid,
         correlation_id: correlation_id,


### PR DESCRIPTION
Protobuf contexts are hashes that have string keys. Add some specs that codify this behavior. The [Elixir side PR](https://github.com/learn-co/railway_ipc/pull/51) has more info.